### PR TITLE
fix(DATAHUB-294): use device_id instead of possibly empty dev_eui

### DIFF
--- a/src/integrations/ttn.test.ts
+++ b/src/integrations/ttn.test.ts
@@ -21,7 +21,6 @@ const issuer = "tsb";
 const ttnPayload = {
   end_device_ids: {
     device_id: "123",
-    dev_eui: "0909120192",
   },
   received_at: new Date().toISOString(),
   uplink_message: {
@@ -271,7 +270,7 @@ describe("tests for the ttn integration", () => {
           name: "test",
           userId,
           projectId: projects[0].id,
-          externalId: ttnPayload.end_device_ids.dev_eui,
+          externalId: ttnPayload.end_device_ids.device_id,
         },
       ]);
     if (!devices) {

--- a/src/integrations/ttn.ts
+++ b/src/integrations/ttn.ts
@@ -29,7 +29,6 @@ interface TTNPostBody {
     };
   };
   end_device_ids: {
-    dev_eui: "string";
     device_id: "string";
     application_ids: {
       application_id: "string";
@@ -42,14 +41,7 @@ const postTTNBodySchema = S.object()
   .title("Validation for data coming from TTN")
   .additionalProperties(true)
 
-  .prop(
-    "end_device_ids",
-    S.object()
-      .prop("device_id", S.string())
-      .required()
-      .prop("dev_eui", S.string())
-      .required()
-  )
+  .prop("end_device_ids", S.object().prop("device_id", S.string()).required())
   .required()
   .additionalProperties(true)
   .prop("received_at", S.string().format(S.FORMATS.DATE_TIME))
@@ -112,13 +104,13 @@ const ttn: FastifyPluginAsync = async (fastify) => {
         throw fastify.httpErrors.unauthorized();
       }
       const { end_device_ids, received_at, uplink_message } = request.body;
-      const { dev_eui } = end_device_ids;
+      const { device_id } = end_device_ids;
       const { decoded_payload, locations } = uplink_message;
       const { measurements } = decoded_payload;
       const { data: devices, error: deviceError } = await fastify.supabase
         .from("devices")
         .select("*")
-        .eq("externalId", dev_eui)
+        .eq("externalId", device_id)
         .eq("projectId", decoded.projectId)
         .eq("userId", decoded.sub);
       if (!devices || devices.length === 0) {


### PR DESCRIPTION
This PR changes the matching of record and device to use the `device_id` of the POST body of a _record_ to find the `externalId` of the _device_.

This is necessary because we cannot rely on the the `dev_eui` being present in a TTN device and its posted data. A `device_id` _has_ to be defined (correct me if I'm wrong) and is therefore more reliable.