### PR TITLE
STADTPULS 379/update lat lon alt on sensor from record

### DIFF
--- a/dev-tools/supabase/dockerfiles/postgres/docker-entrypoint-initdb.d/20-public-tables.sql
+++ b/dev-tools/supabase/dockerfiles/postgres/docker-entrypoint-initdb.d/20-public-tables.sql
@@ -16,7 +16,7 @@ CREATE TABLE "public"."user_profiles" (
     "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "role" "public"."role" DEFAULT 'maker'::"role",
     "url" varchar(100),
-    "description" varchar(500),
+    "description" varchar(200),
     PRIMARY KEY ("id")
 );
 --
@@ -75,7 +75,7 @@ CREATE TABLE "public"."sensors" (
     "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "id" int4 GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     "external_id" varchar(36),
-    "name" varchar(20) constraint name_length_min_3_check check(char_length(name) >= 3) constraint special_character_check check ("name" ~* '^[a-zA-Z0-9_-]*$'),
+    "name" varchar(50) constraint name_length_min_3_check check(char_length(name) >= 3),
     "description" varchar(200),
     "connection_type" "public"."connection_types" NOT NULL DEFAULT 'http'::"connection_types",
     "location" varchar(50),

--- a/dev-tools/supabase/dockerfiles/postgres/docker-entrypoint-initdb.d/20-public-tables.sql
+++ b/dev-tools/supabase/dockerfiles/postgres/docker-entrypoint-initdb.d/20-public-tables.sql
@@ -79,9 +79,9 @@ CREATE TABLE "public"."sensors" (
     "description" varchar(200),
     "connection_type" "public"."connection_types" NOT NULL DEFAULT 'http'::"connection_types",
     "location" varchar(50),
-    "longitude" float4,
-    "latitude" float4,
-    "altitude" float4,
+    "longitude" float8,
+    "latitude" float8,
+    "altitude" float8,
     "category_id" int4 NOT NULL,
     "icon_id" int4,
     "user_id" uuid NOT NULL REFERENCES "public"."user_profiles" (id) ON DELETE CASCADE ON UPDATE CASCADE

--- a/src/__test-utils/index.ts
+++ b/src/__test-utils/index.ts
@@ -237,7 +237,7 @@ export const createSensor: (options: {
     .from<definitions["sensors"]>("sensors")
     .insert([
       {
-        name: name ? name : faker.random.words(3),
+        name: name ? name : faker.random.words(2),
         user_id,
         external_id,
         category_id: 1,

--- a/src/__test-utils/index.ts
+++ b/src/__test-utils/index.ts
@@ -237,7 +237,7 @@ export const createSensor: (options: {
     .from<definitions["sensors"]>("sensors")
     .insert([
       {
-        name: name ? name : faker.random.word(),
+        name: name ? name : faker.random.words(3),
         user_id,
         external_id,
         category_id: 1,

--- a/src/__test-utils/index.ts
+++ b/src/__test-utils/index.ts
@@ -4,6 +4,8 @@ import { createClient } from "@supabase/supabase-js";
 import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import fetch from "node-fetch";
 import { definitions } from "../common/supabase";
+import { TTNPostBody } from "../integrations/ttn";
+export type Sensor = definitions["sensors"];
 
 export const jwtSecret =
   process.env.JWT_SECRET ||
@@ -239,6 +241,9 @@ export const createSensor: (options: {
         user_id,
         external_id,
         category_id: 1,
+        latitude: parseFloat(faker.address.latitude()),
+        longitude: parseFloat(faker.address.longitude()),
+        altitude: faker.datatype.number({ min: 0, max: 100, precision: 0.1 }),
       },
     ]);
   if (!sensors) {
@@ -270,4 +275,32 @@ export const createAuthToken: (opts: {
 
   const resBody = JSON.parse(responseToken.body);
   return getFullResponse ? resBody.data : resBody.data.token;
+};
+
+export const createTTNPayload: (
+  overrides?: TTNPostBody | Record<string, unknown>
+) => TTNPostBody = (overrides) => {
+  return {
+    simulated: true,
+    end_device_ids: {
+      application_ids: {
+        application_id: "foo",
+      },
+
+      device_id: "123",
+    },
+    received_at: new Date().toISOString(),
+    uplink_message: {
+      decoded_payload: { measurements: [1, 2, 3], bytes: [1, 2, 3] },
+      locations: {
+        user: {
+          latitude: 13,
+          longitude: 52,
+          altitude: 23,
+          source: "SOURCE_REGISTRY",
+        },
+      },
+    },
+    ...overrides,
+  };
 };

--- a/src/integrations/http.test.ts
+++ b/src/integrations/http.test.ts
@@ -11,6 +11,7 @@ import {
   supabaseUrl,
   authtokenEndpoint,
   apiVersion,
+  Sensor,
 } from "../__test-utils";
 
 const issuer = "tsb";
@@ -166,7 +167,7 @@ describe("tests for the http integration", () => {
     // end boilerplate
   });
 
-  test("should fail due to deviceId param is not a number", async () => {
+  test("should fail due to sensorId param is not a number", async () => {
     // start boilerplate
     const server = buildServer(buildServerOpts);
     const user = await signupUser();
@@ -245,5 +246,33 @@ describe("tests for the http integration", () => {
     // start boilerplate delete user
     await deleteUser(user.token);
     // end boilerplate
+  });
+
+  test("should change the lat/lon/alt of a sensor via payload of record", async () => {
+    const server = buildServer(buildServerOpts);
+    const user = await signupUser();
+    const authToken = await createAuthToken({ server, userToken: user.token });
+    const sensor = await createSensor({
+      user_id: user.id,
+    });
+    const response = await server.inject({
+      method: "POST",
+      url: `/api/v${apiVersion}/sensors/${sensor.id}/records`,
+      payload: httpPayload,
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+      },
+    });
+    const { data: verifySensor, error } = await server.supabase
+      .from<Sensor>("sensors")
+      .select("*")
+      .eq("id", sensor.id)
+      .single();
+    expect(verifySensor).not.toBeNull();
+    expect(response.statusCode).toBe(201);
+    expect((verifySensor as Sensor).latitude).toBe(httpPayload.latitude);
+    expect((verifySensor as Sensor).longitude).toBe(httpPayload.longitude);
+    expect((verifySensor as Sensor).altitude).toBe(httpPayload.altitude);
+    await deleteUser(user.token);
   });
 });

--- a/src/integrations/http.test.ts
+++ b/src/integrations/http.test.ts
@@ -263,7 +263,10 @@ describe("tests for the http integration", () => {
         Authorization: `Bearer ${authToken}`,
       },
     });
-    const { data: verifySensor, error } = await server.supabase
+    const {
+      data: verifySensor,
+      error: _error,
+    } = await server.supabase
       .from<Sensor>("sensors")
       .select("*")
       .eq("id", sensor.id)

--- a/src/integrations/ttn.ts
+++ b/src/integrations/ttn.ts
@@ -12,7 +12,7 @@ declare module "fastify" {
   }
 }
 
-interface TTNPostBody {
+export interface TTNPostBody {
   [key: string]: unknown;
   received_at: string;
   uplink_message: {
@@ -30,9 +30,9 @@ interface TTNPostBody {
     };
   };
   end_device_ids: {
-    device_id: "string";
+    device_id: string;
     application_ids: {
-      application_id: "string";
+      application_id: string;
     };
   };
   simulated: boolean;

--- a/src/lib/authtokens.error.test.ts
+++ b/src/lib/authtokens.error.test.ts
@@ -1,8 +1,5 @@
 import nock from "nock";
 
-/* eslint-disable jest/no-disabled-tests */
-import { PostgrestError } from "@supabase/postgrest-js/src/lib/types";
-
 import {
   authtokenEndpoint,
   buildServerOpts,


### PR DESCRIPTION
- STADTPULS-379: fix(data type): lat/lon/alt should be float 8
- STADTPULS-379: fix(schema): Unify description lengths and increase name Drops special characters constraion on sensor names
- STADTPULS-379: test(lat/lon/lat): Adds test to verify setting of lat lon
- STADTPULS-379: test(sensor names): Make sensor names have some words
- STADTPULS-379: fix(test): Sensor name needs to be >= 3 chars
- STADTPULS-379: chore: Make prettier happy
- STADTPULS-379: chore: housekeeping