### PR TITLE
STADTPULS 384/remove rpc for update email

### DIFF
--- a/dev-tools/supabase/dockerfiles/postgres/docker-entrypoint-initdb.d/50-remote-procedure-calls.sql
+++ b/dev-tools/supabase/dockerfiles/postgres/docker-entrypoint-initdb.d/50-remote-procedure-calls.sql
@@ -11,19 +11,3 @@ where id = auth.uid();
 delete from auth.users
 where id = auth.uid();
 $$;
---
---
---
---
---
--- Function to allow the user to change his email
--- this will be removed and can be handled using the supabase api directly
--- see https://github.com/supabase/supabase-js/issues/23#issuecomment-684985551
--- TODO: [STADTPULS-384] Remove rpc for update email
-CREATE OR REPLACE FUNCTION public.update_email(new_email text) RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER AS $$ begin
-UPDATE auth.users
-set email = new_email
-where id = auth.uid();
-return found;
-end;
-$$


### PR DESCRIPTION
- STADTPULS-384: chore: Remove RPC to change email.
