### PR TITLE
STADTPULS-391: feat(logging): Disable logging on health check routes

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -78,6 +78,7 @@ export const buildServer: (options: {
     server.route({
       method: ["GET"],
       url: path,
+      logLevel: "warn",
       handler: async (request, reply) => {
         reply.send({
           comment: "healthcheck",


### PR DESCRIPTION
Since it is only noise in the render.com console