### PR TITLE
STADTPULS-407: fix(schema): Make name on user_profiles not null

### DIFF
--- a/dev-tools/supabase/dockerfiles/postgres/docker-entrypoint-initdb.d/20-public-tables.sql
+++ b/dev-tools/supabase/dockerfiles/postgres/docker-entrypoint-initdb.d/20-public-tables.sql
@@ -11,7 +11,7 @@ CREATE TYPE "public"."role" AS ENUM ('maker', 'taker');
 DROP TABLE IF EXISTS "public"."user_profiles";
 CREATE TABLE "public"."user_profiles" (
     "id" uuid NOT NULL,
-    "name" varchar(20) constraint name_length_min_3_check check(char_length(name) >= 3) constraint special_character_check check ("name" ~* '^[a-zA-Z0-9_-]*$') constraint name_unique UNIQUE,
+    "name" varchar(36) NOT NULL constraint name_length_min_3_check check(char_length(name) >= 3) constraint special_character_check check ("name" ~* '^[a-zA-Z0-9_-]*$') constraint name_unique UNIQUE DEFAULT uuid_generate_v4 ()::text,
     "display_name" varchar(50),
     "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "role" "public"."role" DEFAULT 'maker'::"role",

--- a/src/lib/__tests__/signup.test.ts
+++ b/src/lib/__tests__/signup.test.ts
@@ -12,6 +12,7 @@ import {
   deleteUser,
   purgeInbox,
   signupUser,
+  supabase,
   truncateTables,
 } from "../../__test-utils";
 import { closePool } from "../../__test-utils/truncate-tables";
@@ -106,6 +107,7 @@ describe("signup POST tests", () => {
         name,
       },
     });
+
     const messages = await checkInbox("me");
     expect(messages).toHaveLength(1);
     expect(messages).toMatchSnapshot([
@@ -122,5 +124,12 @@ describe("signup POST tests", () => {
       },
     ]);
     expect(response.statusCode).toBe(204);
+    const { data: user, error } = await supabase
+      .from("user_profiles")
+      .select("name")
+      .eq("name", name)
+      .single();
+    expect(error).toBeNull();
+    expect(user.name).toBe(name);
   });
 });


### PR DESCRIPTION
Sets as  default a 36 char uuid. When using the signup route of the api this is
replaced with the userrname provided.
