### PR TITLE
fix(pagination): Fix nextPage field in reply body

### DIFF
--- a/src/lib/__tests__/__snapshots__/sensors.test.ts.snap
+++ b/src/lib/__tests__/__snapshots__/sensors.test.ts.snap
@@ -21,7 +21,6 @@ exports[`all /api/v3/sensors tests get list of all sensors GET > 1000 should hav
 Object {
   "data": Any<Array>,
   "nextPage": "/api/v3/sensors?offset=1000&limit=1000",
-  "url": "/api/v3/sensors",
 }
 `;
 
@@ -43,6 +42,5 @@ Object {
       "name": "test",
     },
   ],
-  "url": "/api/v3/sensors/1",
 }
 `;

--- a/src/lib/__tests__/pagination.test.ts
+++ b/src/lib/__tests__/pagination.test.ts
@@ -1,0 +1,67 @@
+/* eslint-disable jest/require-top-level-describe */
+
+import { definitions } from "../../common/supabase";
+import {
+  connectPool,
+  truncateTables,
+  closePool,
+  buildServerOpts,
+  createSensor,
+  sensorsEndpoint,
+  signupUser,
+} from "../../__test-utils";
+import { createRecords } from "../../__test-utils/create-records";
+import buildServer from "../server";
+type JsonResponseRecords = {
+  nextPage?: string;
+  data: definitions["records"][];
+};
+beforeAll(async () => {
+  await connectPool();
+});
+beforeEach(async () => {
+  await truncateTables();
+});
+afterAll(async () => {
+  await truncateTables();
+  await closePool();
+});
+describe("pagination", () => {
+  test("should have pagination with limit and offset", async () => {
+    const server = buildServer(buildServerOpts);
+    const user = await signupUser();
+    const sensor = await createSensor({ user_id: user.id });
+    await createRecords({
+      sensor_id: sensor.id,
+      numberOfRecords: 3000,
+    });
+    const response1 = await server.inject({
+      method: "GET",
+      url: `${sensorsEndpoint}/${sensor.id}/records`,
+    });
+    const json1 = response1.json<JsonResponseRecords>();
+
+    expect(json1.data).toHaveLength(1000);
+    expect(json1.nextPage).toBeDefined();
+    expect(json1.nextPage).toMatchInlineSnapshot(
+      `"/api/v3/sensors/1/records?offset=1000&limit=1000"`
+    );
+
+    const response2 = await server.inject({
+      method: "GET",
+      url: json1.nextPage,
+    });
+    const json2 = response2.json<JsonResponseRecords>();
+    expect(json2.nextPage).toMatchInlineSnapshot(
+      `"/api/v3/sensors/1/records?offset=2000&limit=1000"`
+    );
+    const response3 = await server.inject({
+      method: "GET",
+      url: json2.nextPage,
+    });
+    const json3 = response3.json<JsonResponseRecords>();
+    expect(json3.nextPage).toMatchInlineSnapshot(
+      `"/api/v3/sensors/1/records?offset=3000&limit=1000"`
+    );
+  });
+});

--- a/src/lib/__tests__/reply-utils.test.ts
+++ b/src/lib/__tests__/reply-utils.test.ts
@@ -11,7 +11,6 @@ describe("utilities to build reply payload", () => {
       payload: [],
     });
     expect(replyPayload.nextPage).not.toBeDefined();
-    expect(replyPayload.url).toBeDefined();
     expect(replyPayload.data).toHaveLength(0);
   });
 
@@ -21,7 +20,6 @@ describe("utilities to build reply payload", () => {
       payload: [1, 2, 3],
     });
     expect(replyPayload.nextPage).not.toBeDefined();
-    expect(replyPayload.url).toBeDefined();
     expect(replyPayload.data).toHaveLength(3);
   });
 
@@ -31,7 +29,6 @@ describe("utilities to build reply payload", () => {
       payload: { id: 1 },
     });
     expect(replyPayload.nextPage).not.toBeDefined();
-    expect(replyPayload.url).toBeDefined();
     expect(Array.isArray(replyPayload.data)).toBe(true);
     expect(replyPayload.data).toHaveLength(1);
   });
@@ -42,7 +39,6 @@ describe("utilities to build reply payload", () => {
       payload: null,
     });
     expect(replyPayload.nextPage).not.toBeDefined();
-    expect(replyPayload.url).toBeDefined();
     expect(Array.isArray(replyPayload.data)).toBe(true);
     expect(replyPayload.data).toHaveLength(0);
   });
@@ -59,7 +55,6 @@ describe("utilities to build reply payload", () => {
     });
 
     expect(replyPayload.nextPage).toBeDefined();
-    expect(replyPayload.url).toBeDefined();
     expect(replyPayload.nextPage).toBeDefined();
     expect(replyPayload.nextPage).toBe("/api/v3/sensors?offset=1&limit=1000");
   });

--- a/src/lib/__tests__/sensors.test.ts
+++ b/src/lib/__tests__/sensors.test.ts
@@ -54,7 +54,6 @@ describe(`all ${sensorsEndpoint} tests`, () => {
     expect(response.statusCode).toBe(200);
     expect(response.json()).toStrictEqual({
       data: [],
-      url: sensorsEndpoint,
     });
   });
   test("list of all sensors HEAD", async () => {
@@ -113,7 +112,6 @@ describe(`all ${sensorsEndpoint} tests`, () => {
     const lastItem = json.data[json.data.length - 1];
     expect(json).toMatchSnapshot({
       data: expect.any(Array),
-      url: sensorsEndpoint,
       nextPage: "/api/v3/sensors?offset=1000&limit=1000",
     });
     expect(lastItem.id).toBe(1000);
@@ -125,7 +123,6 @@ describe(`all ${sensorsEndpoint} tests`, () => {
       url: json.nextPage,
     });
     const json2 = response2.json<{
-      url: string;
       nextPage: string;
       data: Omit<definitions["sensors"], "user_id">[];
     }>();
@@ -170,7 +167,6 @@ describe(`single ${sensorsEndpoint}/:sensorId tests`, () => {
     });
     expect(response.statusCode).toBe(200);
     expect(response.json()).toMatchSnapshot({
-      url: `${sensorsEndpoint}/${sensor.id}`,
       data: [
         {
           altitude: expect.any(Number),

--- a/src/lib/reply-utils.ts
+++ b/src/lib/reply-utils.ts
@@ -5,7 +5,6 @@
 
 export interface ReplyPayload<Payload> {
   comment?: string;
-  url: string;
   data: Payload | Payload[];
   nextPage?: string;
 }
@@ -31,10 +30,12 @@ export function buildReplyPayload<PayloadType>({
 }): ReplyPayload<PayloadType> {
   // TODO: This function needs to be smarter and should compare unitLength and payload
   let nextPage: string | undefined = undefined;
-
+  const strippedUrl = url.split("?")[0];
   if (contentRange && payload && Array.isArray(payload) && payload.length > 0) {
     const { offset, limit } = contentRange;
-    nextPage = `${url}?offset=${offset + payload.length}&limit=${limit}`;
+    nextPage = `${strippedUrl}?offset=${
+      offset + payload.length
+    }&limit=${limit}`;
   }
   let data: PayloadType[] = [];
   if (payload && Array.isArray(payload)) {
@@ -45,7 +46,6 @@ export function buildReplyPayload<PayloadType>({
   const empty: PayloadType[] = [];
   return {
     nextPage,
-    url,
     data: payload ? data : empty,
   };
 }

--- a/src/lib/sensors-records.ts
+++ b/src/lib/sensors-records.ts
@@ -14,7 +14,6 @@ import {
   buildReplyHeaders,
   buildReplyPayload,
   ContentRange,
-  RangeUnit,
 } from "./reply-utils";
 
 // type Categories = definitions["categories"]["name"];


### PR DESCRIPTION
- fix(pagination): Had duplicate limit & offset query param
  The URL was build using the request.url. If the URL had query params
  the fields `offset` and `limit` just got appended and then where duplicated.
  This made all requests fail that loop through the responses and took the
  `nextPage` url as the indicator if there are more records.
  The result was that it only worked to make two iterations. Since all the
  tests only checked one iteration this was not seen.
- refactor(payload): Removes url as payload field
  Since the user knows which url he requested we don't need that cruft
