### PR TITLE
feat(http integration): allow additional props in body

### DIFF
--- a/src/integrations/http.test.ts
+++ b/src/integrations/http.test.ts
@@ -235,6 +235,37 @@ describe("tests for the http integration", () => {
     await deleteUser(user.token);
     // end boilerplate
   });
+
+  test("should pass with additional properties", async () => {
+    // start boilerplate setup test
+    const server = buildServer(buildServerOpts);
+    const user = await signupUser();
+
+    const authToken = await createAuthToken({
+      server,
+      userToken: user.token,
+    });
+    const device = await createSensor({
+      user_id: user.id,
+    });
+    // end boilerplate
+
+    const response = await server.inject({
+      method: "POST",
+      url: `/api/v${apiVersion}/sensors/${device.id}/records`,
+      payload: {
+        additionalProperties: { something: "unexpected" },
+        ...httpPayload,
+      },
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+      },
+    });
+    expect(response.statusCode).toBe(201);
+    // start boilerplate delete user
+    await deleteUser(user.token);
+    // end boilerplate
+  });
   // test should throw an PostgrestError
   // how can we mock the call to supabase.from("authtokens")
   // eslint-disable-next-line jest/no-disabled-tests

--- a/src/integrations/http.ts
+++ b/src/integrations/http.ts
@@ -29,7 +29,7 @@ const mountPoint = config.get<string>("mountPoint");
 const postHTTPBodySchema = S.object()
   .id("/integration/http")
   .title("Validation for data coming in via HTTP")
-  .additionalProperties(false)
+  .additionalProperties(true)
   .prop("latitude", S.number().minimum(-90).maximum(90))
   .prop("longitude", S.number().minimum(-180).maximum(180))
   .prop("altitude", S.number().minimum(0).maximum(10000))


### PR DESCRIPTION
For parity with ttn we allow additional props
